### PR TITLE
build: add storage:link command to Dokerfile and Readme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN chown -R www-data:www-data /var/www/html/storage /var/www/html/bootstrap/cac
 
 RUN php artisan key:generate && php artisan config:cache
 
-#RUN php artisan migrate --seed --force
+RUN php artisan storage:link
 
 EXPOSE 80
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ php artisan migrate --seed
 # Set the project secret key
 php artisan key:generate
 
+# Create the symbolic links to storage
+php artisan storage:link
+
 # Start application
 php artisan serve
 ```


### PR DESCRIPTION
# O que foi feito
adicionado comando `php artisan storage:link` no Dockerfile e no Readme para documentação.

# Por que
Manter build e documentação atualizados.