### PR TITLE
feat: add image to publication

### DIFF
--- a/app/Http/Controllers/PublicationController.php
+++ b/app/Http/Controllers/PublicationController.php
@@ -41,9 +41,17 @@ class PublicationController extends Controller
     public function store(StorePublicationRequest $request)
     {
         $publication = $request->validated();
-        $publication['user_id'] = Auth::id();
+        if(isset($publication['image'])) {
+            Storage::disk('local')->put("public/publications/images", $publication['image']);
+        }
 
-        Publication::create($publication);
+        Publication::create([
+            'user_id' => Auth::id(),
+            'title' => $publication['title'],
+            'content' => $publication['content'],
+            'image_url' => isset($publication['image']) ? Storage::url("public/publications/images/" . $publication['image']->hashName()) : null,
+            'video_url' => $publication['video_url'] ?? null,
+        ]);
 
         return redirect()->route('home');
     }
@@ -80,17 +88,5 @@ class PublicationController extends Controller
     public function destroy(Publication $publication)
     {
         //
-    }
-
-    public function postPublication(Request $request)
-    {
-
-        if ($request->hasFile('imgUpload')) {
-        $file = $request->file('imgUpload');
-        $fileName = uniqid() . '.' . $file->getClientOriginalExtension();
-
-        $file->move(public_path('uploads'), $fileName);
-
-        }
     }
 }

--- a/app/Http/Requests/StorePublicationRequest.php
+++ b/app/Http/Requests/StorePublicationRequest.php
@@ -24,6 +24,7 @@ class StorePublicationRequest extends FormRequest
         return [
             'title' => 'required|between:1,100',
             'content' => 'required|between:2,500',
+            'image' => 'image',
         ];
     }
 
@@ -39,6 +40,7 @@ class StorePublicationRequest extends FormRequest
             'title.between' => 'Título deve ter entre 1 e 100 caracteres',
             'content.required' => 'Conteúdo da publicação é obrigatório',
             'content.between' => 'Conteúdo deve ter entre 1 e 100 caracteres',
+            'image.image' => 'Deve ser uma imagem válida (jpg, jpeg, png, bmp, gif, svg, ou webp).',
         ];
     }
 }

--- a/app/Models/Publication.php
+++ b/app/Models/Publication.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
 
 class Publication extends Model
 {
@@ -22,6 +23,8 @@ class Publication extends Model
         'title',
         'content',
         'user_id',
+        'image_url',
+        'video_url',
     ];
 
     /**

--- a/database/migrations/2023_10_18_001344_create_publications_table.php
+++ b/database/migrations/2023_10_18_001344_create_publications_table.php
@@ -16,6 +16,8 @@ return new class extends Migration
             $table->foreignId('user_id');
             $table->string('title');
             $table->longText('content');
+            $table->string('image_url')->nullable();
+            $table->string('video_url')->nullable();
             $table->timestamps();
             $table->softDeletes();
 

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -40,13 +40,13 @@
 
                 <div class="iconsAndButton">
                     <div class="icons">
-                        <button class="btnFileForm">
-                            <img src="img/img.svg" alt="Adicionar uma imagem">
-                            <input type="file" id="imgUpload" name="imgUpload" accept=".jpg, .jpeg, .png, .gif*" style="display: none;">
+                        <button type="button" class="btnFileForm">
+                            <img src="img/img.svg" alt="Adicionar uma imagem" />
+                            <input type="file" id="imgUpload" name="image" accept=".jpg, .jpeg, .png, .gif*" style="display: none;">
                         </button>
 
-                        <button class="btnFileForm">
-                            <img src="img/video.svg" alt="Adicionar um video">
+                        <button type="button" class="btnFileForm">
+                            <img src="img/video.svg" alt="Adicionar um video" />
                             <input type="file" id="videoUpload" name="videoUpload" accept="video/*" style="display: none;">
                         </button>
 
@@ -73,7 +73,7 @@
 
                 <h2>{{ $publication->title }}</h2>
                 <p>{{ $publication->content }}</p>
-
+                <img src="{{ $publication->image_url }}" alt="">
                 <div class="actionBtnPost">
                     <button type="button" class="filesPost like">
                         @if(in_array($loggedUser->id, $publication->usersLike))
@@ -90,6 +90,8 @@
                         <a class="styleFont" href="{{ route('get.publication', $publication->id) }}">
                             <img src="img/deslik1.svg" alt="Comentar">Comentar
                         </a>
+                    </button>
+                </div>
             </li>
             @endforeach
         </ul>

--- a/resources/views/publication.blade.php
+++ b/resources/views/publication.blade.php
@@ -36,6 +36,7 @@
         <div>
             <h2>{{ $publication->title }}</h2>
             <p>{{ $publication->content }}</p>
+            <img src="{{ $publication->image_url }}" alt="">
         </div>
         @foreach($publication->replies as $reply)
         <div class="comment">


### PR DESCRIPTION
# O que foi feito

Implementa funcionalidade de adicionar imagem à publicação.

# Comentário

- As imagens quebram o layout da página home e da página de comentário da publicação.
- Penso que vale melhorar a pré-visualização da imagem na inserção.
- O Menu ainda está quebrando.